### PR TITLE
Print single instead of double equals sign

### DIFF
--- a/act/expr2.cc
+++ b/act/expr2.cc
@@ -132,7 +132,7 @@ static void _print_expr (char *buf, int sz, Expr *e, int prec)
   case E_GT:  EMIT_BIN (7, ">"); break;
   case E_LE:  EMIT_BIN (7, "<="); break;
   case E_GE:  EMIT_BIN (7, ">="); break;
-  case E_EQ:  EMIT_BIN (7, "=="); break;
+  case E_EQ:  EMIT_BIN (7, "="); break;
   case E_NE:  EMIT_BIN (7, "!="); break;
 
   case E_AND: EMIT_BIN (6, "&"); break;

--- a/act/test/misc/runs/8.act.stderr
+++ b/act/test/misc/runs/8.act.stderr
@@ -1,5 +1,5 @@
 In expanding ::<Global>
 *** Assertion failed ***
- assertion: i==k
+ assertion: i=k
    message: check hex/bin
 FATAL: Aborted execution on failed assertion


### PR DESCRIPTION
ACT currently prints the E_EQ expression with a double equals sign, but the parser expects a single equals sign, so some expressions printed using the ACT tools aren't parsable. This commit makes the expression print function use a single equals sign.

Since the expression printing code is widely used, there may be potential consequences to this change that I don't anticipate, so please let me know if this change isn't possible for some reason.