### PR TITLE
make shared libraries load from runtime ACT_HOME by relative search path

### DIFF
--- a/configure
+++ b/configure
@@ -32,7 +32,7 @@ baseos=`$full_pathname/scripts/getbaseos`;
 
 installdir=/usr/local/cad
 
-if [ $# -eq 1 ]
+if [ $# -gt 0 ]
 then
       installdir=$1
 fi
@@ -92,6 +92,16 @@ then
     mkdir $installdir/act
 fi
 
+# get additional CFLAGS and pass them through
+if [ $# -gt 1 ]
+then
+    case $2 in
+    "CFLAGS="*) addon_cflags=${2#CFLAGS=}
+     addon_cflags=${addon_cflags#\"}
+     addon_cflags=${addon_cflags#\'}
+     echo "CFLAGS: $addon_cflags"
+    esac
+fi
 
 #
 # shared linking on macos
@@ -103,14 +113,17 @@ then
     sh_exe_options=
 else
     sh_build="\"-shared -DPIC -fPIC\""
-    sh_link="\"-shared -Wl,-x,-rpath=$ACT_HOME/lib\""
-    sh_exe_options="\"-Wl,-rpath=$ACT_HOME/lib\""
+    # the RUNPATH so object search parameter are relative to $ACT_HOME during runtime, and as backup the $ORIGIN of the executable
+    # libraries and executables are parsed differently by the build system hand have therefor different escape patterns
+    sh_link="\"-shared -Wl,-x,-rpath=\\\$ACT_HOME/lib,-rpath=\\\$ORIGIN/../lib\""
+    sh_exe_options="\"-Wl,-rpath=\\\$\$ACT_HOME/lib,-rpath=\\$\$ORIGIN/../lib\""
 fi    
 
 
 c_compiler_name=gcc
 cxx_compiler_name=g++
-c_compiler_flags=-O2
+# the double parentesis are needed beause of double parcing in the check script and are removed in the makefile to have the intended behaviour
+c_compiler_flags="\"-O2 ${addon_cflags}\""
 make_program=gmake
 myranlib=ranlib
 

--- a/configure
+++ b/configure
@@ -113,10 +113,10 @@ then
     sh_exe_options=
 else
     sh_build="\"-shared -DPIC -fPIC\""
-    # the RUNPATH so object search parameter are relative to $ACT_HOME during runtime, and as backup the $ORIGIN of the executable
+    # the RUNPATH shared object search parameter are relative the location of the binary during runtime, and as backup the compile time $ACT_HOME path is used
     # libraries and executables are parsed differently by the build system hand have therefor different escape patterns
-    sh_link="\"-shared -Wl,-x,-rpath=\\\$ACT_HOME/lib,-rpath=\\\$ORIGIN/../lib\""
-    sh_exe_options="\"-Wl,-rpath=\\\$\$ACT_HOME/lib,-rpath=\\$\$ORIGIN/../lib\""
+    sh_link="\"-shared -Wl,-x,-rpath=\\\$ORIGIN/../lib,-rpath=$ACT_HOME/lib\""
+    sh_exe_options="\"-Wl,-rpath=\\$\$ORIGIN/../lib,-rpath=$ACT_HOME/lib\""
 fi    
 
 

--- a/configure
+++ b/configure
@@ -111,12 +111,17 @@ then
     sh_build=-fPIC 
     sh_link=-dynamiclib
     sh_exe_options=
-else
+elif [ "x$baseos" = "xlinux" ] || [ "x$baseos" = "xsolaris" ]
+then
     sh_build="\"-shared -DPIC -fPIC\""
     # the RUNPATH shared object search parameter are relative the location of the binary during runtime, and as backup the compile time $ACT_HOME path is used
     # libraries and executables are parsed differently by the build system hand have therefor different escape patterns
     sh_link="\"-shared -Wl,-x,-rpath=\\\$ORIGIN/../lib,-rpath=$ACT_HOME/lib\""
     sh_exe_options="\"-Wl,-rpath=\\$\$ORIGIN/../lib,-rpath=$ACT_HOME/lib\""
+else
+    sh_build="\"-shared -DPIC -fPIC\""
+    sh_link="\"-shared -Wl,-x,-rpath=$ACT_HOME/lib\""
+    sh_exe_options="\"-Wl,-rpath=$ACT_HOME/lib\""
 fi    
 
 

--- a/scripts/Makefile.std
+++ b/scripts/Makefile.std
@@ -74,7 +74,7 @@ DFLAGS=-DARCH_$(ARCH) -DOS_$(OS) -DBASEOS_$(BASEOS) -I$(INSTALLINC) # -D_FORTIFY
 ifndef DEPEND_FLAGS
 DEPEND_FLAGS=-I.
 endif
-CFLAGS=$(C_COMPILER_FLAGS) 
+CFLAGS=$(subst ",,$(C_COMPILER_FLAGS)) 
 
 
 all: installincsub dependsub allsub move-in $(TARGETLIBS) install_lib install_inc $(TARGETS) $(EXTRA) move-out postsub

--- a/scripts/check
+++ b/scripts/check
@@ -66,9 +66,9 @@ int main (void)
 
 EOM
 
-
+# the $C_COMPILER_FLAGS enable to load so files form a custom path
 echo "  ... looking for editline"
-if ! $C_COMPILER_NAME -c __tst1.c  >/dev/null 2>&1
+if ! $C_COMPILER_NAME $C_COMPILER_FLAGS -c __tst1.c  >/dev/null 2>&1
 then
 	rm -f __tst1.c
 	echo "Did not find libeditline on the system"
@@ -76,7 +76,7 @@ then
 fi
 
 echo "  ... looking for zlib"
-if ! $C_COMPILER_NAME __tst1.o -lz >/dev/null 2>&1
+if ! $C_COMPILER_NAME $C_COMPILER_FLAGS __tst1.o -lz >/dev/null 2>&1
 then
 	rm -f __tst1.c
 	echo "Did not find zlib on the system"

--- a/simulation/prsim/Makefile
+++ b/simulation/prsim/Makefile
@@ -32,7 +32,7 @@ SRCS=$(OBJS:.o=.c)
 include $(VLSI_TOOLS_SRC)/scripts/Makefile.std
 
 $(BIN1): $(LIB) $(OBJS1) $(LIBDEPEND) $(SCMCLIDEPEND)
-	$(CXX) $(CFLAGS) $(OBJS1) -o $(BIN1) $(LIBCOMMON) $(LIBACTSCMCLI) -ledit -ldl
+	$(CXX) $(CFLAGS) $(OBJS1) -o $(BIN1) $(LIBCOMMON) $(LIBACTSCMCLI) -ledit $(SH_EXE_OPTIONS) -ldl
 
 $(BIN2): $(LIB) $(OBJS2) $(LIBDEPEND)
 	$(CXX) $(CFLAGS) $(OBJS2) -o $(BIN2) $(LIBCOMMON)


### PR DESCRIPTION
# What does this pull request improve:

- the compiled in search path for shared object libs (RUNPATH/ rpath) is no longer hard coded to the ACT_HOME path at compile time, but is now taking runtime location of the binary and searches relative to it, the old search path is kept for backup.
- the configure script will accept external CFLAGS passed to it to enable custom include/link locations for example if libedit or zlib are installed in a custom path.
- adds runpath to compile flags for prsim (because of libedit)

# Why do that change:

This changes where triggered by me having to build the act tool chain for a shared network install. In my case this install is mounted to both centos 7 servers and ubuntu 20.04LTS local machines. To avoid having different binaries and having to install dependencies on all local machines I decided to put the required external so libs also in ACT_HOME/lib.

The build scripts I put at https://github.com/bics-rug/act-toolchain-build , I could build+publish nightlys from the oss parts (if you think that's helpfull for others) that should run on most gnu/linux distributions >2013 out of the box, without installing dependencies (the CI is testing that). The CI is already building a subset of the tools for the start, more will come. I am not packaging them at the moment but that would be easy.

# changes to the binaries look like:

binaries:
```
readelf -d act/bin/interact | head -14

Dynamic section at offset 0x1ed60 contains 35 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libactpass_sh.so]
 0x0000000000000001 (NEEDED)             Shared library: [libact_sh.so]
 0x0000000000000001 (NEEDED)             Shared library: [libvlsilib_sh.so]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libedit.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/user/git/act-toolchain-build/act/lib]
 0x000000000000000c (INIT)               0x6000

```

libraries:
```
readelf -d act/lib/libactchp2prspass.so | head -11

Dynamic section at offset 0xdd68 contains 30 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libact_sh.so]
 0x0000000000000001 (NEEDED)             Shared library: [libvlsilib_sh.so]
 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/user/git/act-toolchain-build-oss/act/lib]
 0x000000000000000c (INIT)               0x4000

```
before it was :
```
 0x000000000000001d (RUNPATH)            Library runpath: [/home/user/git/act-toolchain-build-oss/act/lib]
 
for $ACT_HOME = /home/user/git/act-toolchain-build-oss/act  set at compile time
```