### PR TITLE
Adding env var for test runners to use binary in act_home

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,25 +16,10 @@ jobs:
           ./configure $ACT_HOME
           ./build 
           make install
+          export ACT_TEST_VERBOSE=1
           make runtest
-
-   centos8:
-     docker:
-       - image: centos:8
-     steps:
-       - checkout
-       - run: |
-          yum install -y 'dnf-command(config-manager)'
-          yum config-manager --set-enabled powertools -y
-          yum install -y gcc gcc-c++ diffutils make libedit-devel zlib-devel m4
-          mkdir install
-          export VLSI_TOOLS_SRC=`pwd`
-          export ACT_HOME=$VLSI_TOOLS_SRC/install
-          ./configure $ACT_HOME
-          ./build
-          make install
+          export ACT_TEST_INSTALL=1
           make runtest
-          
 
 
 workflows:

--- a/act/test/dl/run.sh
+++ b/act/test/dl/run.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -61,6 +67,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -72,6 +81,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/dl/run_vg.sh
+++ b/act/test/dl/run_vg.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -61,6 +67,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -72,6 +81,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/dl/validate.sh
+++ b/act/test/dl/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/act/test/print/run.sh
+++ b/act/test/print/run.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -57,6 +63,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -68,6 +77,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/print/run_vg.sh
+++ b/act/test/print/run_vg.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -57,6 +63,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -68,6 +77,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/print/validate.sh
+++ b/act/test/print/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/act/test/run_subdir.sh
+++ b/act/test/run_subdir.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -57,6 +63,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -68,6 +77,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/run_subdir_vg.sh
+++ b/act/test/run_subdir_vg.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -57,6 +63,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -68,6 +77,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/act/test/validate_subdir.sh
+++ b/act/test/validate_subdir.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACT=../act-test.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act-test.$EXT ]; then
+  ACT=$ACT_HOME/bin/act-test
+  echo "testing installation"
+echo
+else
+  ACT=../act-test.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/act2v/test/run.sh
+++ b/transform/act2v/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../act2v.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act2v.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/act2v
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../act2v.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.x.t.stdout runs/$i.y.t.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/act2v/test/validate.sh
+++ b/transform/act2v/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../act2v.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../act2v.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/act2v
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../act2v.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/aflat/test/run.sh
+++ b/transform/aflat/test/run.sh
@@ -9,8 +9,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../aflat.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../aflat.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/aflat
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../aflat.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -65,6 +70,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.x.t.stdout runs/$i.y.t.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -76,6 +84,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/aflat/test/run_vg.sh
+++ b/transform/aflat/test/run_vg.sh
@@ -9,8 +9,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../aflat.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../aflat.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/aflat
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../aflat.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -65,6 +70,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.x.t.stdout runs/$i.y.t.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -76,6 +84,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/aflat/test/validate.sh
+++ b/transform/aflat/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../aflat.$EXT
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../aflat.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/aflat
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../aflat.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/ext2sp/test/run.sh
+++ b/transform/ext2sp/test/run.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../ext2sp.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../ext2sp.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/ext2sp
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../ext2sp.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -64,6 +69,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -75,6 +83,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/ext2sp/test/run_vg.sh
+++ b/transform/ext2sp/test/run_vg.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../ext2sp.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../ext2sp.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/ext2sp
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../ext2sp.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -64,6 +69,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -75,6 +83,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/ext2sp/test/validate.sh
+++ b/transform/ext2sp/test/validate.sh
@@ -3,8 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../ext2sp.$EXT 
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../ext2sp.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/ext2sp
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../ext2sp.$EXT
+fi
 if [ $# -eq 0 ]
 then
 	list=[0-9]*.ext

--- a/transform/prs2cells/test/run.sh
+++ b/transform/prs2cells/test/run.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2cells.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2cells.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2cells
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2cells.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -64,6 +69,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -76,6 +84,9 @@ do
 		fi
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if ! cmp runs/$i.t.cellout runs/$i.cellout >/dev/null 2>/dev/null
 	then
@@ -88,6 +99,9 @@ do
 		fi
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.cellout runs/$i.cellout
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2cells/test/run_vg.sh
+++ b/transform/prs2cells/test/run_vg.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2cells.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2cells.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2cells
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2cells.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -64,6 +69,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -76,6 +84,9 @@ do
 		fi
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if ! cmp runs/$i.t.cellout runs/$i.cellout >/dev/null 2>/dev/null
 	then
@@ -88,6 +99,9 @@ do
 		fi
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.cellout runs/$i.cellout
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2cells/test/validate.sh
+++ b/transform/prs2cells/test/validate.sh
@@ -3,8 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2cells.$EXT 
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2cells.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2cells
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2cells.$EXT
+fi
 if [ $# -eq 0 ]
 then
 	list=[0-9]*.act

--- a/transform/prs2net/test/run.sh
+++ b/transform/prs2net/test/run.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2net.$EXT 
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2net.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2net
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2net.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -69,6 +74,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -80,6 +88,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2net/test/run_vg.sh
+++ b/transform/prs2net/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2net.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2net.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2net
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2net.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -64,6 +70,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -75,6 +84,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2net/test/validate.sh
+++ b/transform/prs2net/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2net.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2net.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2net
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2net.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/prs2sim/test/run.sh
+++ b/transform/prs2sim/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2sim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2sim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2sim
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2sim.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2sim/test/run_vg.sh
+++ b/transform/prs2sim/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2sim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2sim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2sim
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2sim.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/prs2sim/test/validate.sh
+++ b/transform/prs2sim/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../prs2sim.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../prs2sim.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/prs2sim
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../prs2sim.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/testing/arb/test/run.sh
+++ b/transform/testing/arb/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_arbpass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_arbpass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_arbpass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_arbpass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/arb/test/run_vg.sh
+++ b/transform/testing/arb/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_arbpass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_arbpass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_arbpass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_arbpass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/arb/test/validate.sh
+++ b/transform/testing/arb/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_arbpass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_arbpass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_arbpass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_arbpass.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/testing/inline/test/run.sh
+++ b/transform/testing/inline/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_inlinepass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_inlinepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_inlinepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_inlinepass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/inline/test/run_vg.sh
+++ b/transform/testing/inline/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_inlinepass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_inlinepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_inlinepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_inlinepass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/inline/test/validate.sh
+++ b/transform/testing/inline/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_inlinepass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_inlinepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_inlinepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_inlinepass.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/testing/mem/test/run.sh
+++ b/transform/testing/mem/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_mempass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_mempass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_mempass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_mempass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/mem/test/run_vg.sh
+++ b/transform/testing/mem/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_mempass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_mempass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_mempass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_mempass.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -66,6 +72,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +86,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/mem/test/validate.sh
+++ b/transform/testing/mem/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_mempass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_mempass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_mempass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_mempass.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/testing/state/test/run.sh
+++ b/transform/testing/state/test/run.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_statepass.$EXT
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_statepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_statepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_statepass.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -66,6 +71,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +85,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/state/test/run_vg.sh
+++ b/transform/testing/state/test/run_vg.sh
@@ -10,8 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_statepass.$EXT 
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_statepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_statepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_statepass.$EXT
+fi
 check_echo=0
 myecho()
 {
@@ -66,6 +71,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -77,6 +85,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/testing/state/test/validate.sh
+++ b/transform/testing/state/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_statepass.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_statepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_statepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_statepass.$EXT
+fi
 
 if [ $# -eq 0 ]
 then

--- a/transform/testing/state/test/view.sh
+++ b/transform/testing/state/test/view.sh
@@ -3,8 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../test_statepass.$EXT 
-
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../test_statepass.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/test_statepass
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../test_statepass.$EXT
+fi
 if [ $# -eq 0 ]
 then
 	list=*.act

--- a/transform/v2act/test/run.sh
+++ b/transform/v2act/test/run.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../v2act.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../v2act.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/v2act
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../v2act.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -64,6 +70,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -75,6 +84,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/v2act/test/run_vg.sh
+++ b/transform/v2act/test/run_vg.sh
@@ -10,7 +10,13 @@ echo
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../v2act.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../v2act.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/v2act
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../v2act.$EXT
+fi
 
 check_echo=0
 myecho()
@@ -64,6 +70,9 @@ do
 		myecho "** FAILED TEST $i: stdout"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stdout runs/$i.stdout
+        fi
 	fi
 	if ! cmp runs/$i.t.stderr runs/$i.stderr >/dev/null 2>/dev/null
 	then
@@ -75,6 +84,9 @@ do
 		myecho " stderr"
 		fail=`expr $fail + 1`
 		ok=0
+		if [ ! x$ACT_TEST_VERBOSE = x ]; then
+            diff runs/$i.t.stderr runs/$i.stderr
+        fi
 	fi
 	if [ $ok -eq 1 ]
 	then

--- a/transform/v2act/test/validate.sh
+++ b/transform/v2act/test/validate.sh
@@ -3,7 +3,13 @@
 ARCH=`$VLSI_TOOLS_SRC/scripts/getarch`
 OS=`$VLSI_TOOLS_SRC/scripts/getos`
 EXT=${ARCH}_${OS}
-ACTTOOL=../v2act.$EXT 
+if [ ! x$ACT_TEST_INSTALL = x ] || [ ! -f ../v2act.$EXT ]; then
+  ACTTOOL=$ACT_HOME/bin/v2act
+  echo "testing installation"
+echo
+else
+  ACTTOOL=../v2act.$EXT
+fi
 
 if [ $# -eq 0 ]
 then


### PR DESCRIPTION
added $ACT_TEST_INSTALL to trigger testing of installed sources in $ACT_HOME
added $ACT_TEST_VERBOSE to print got vs expected output for CI, on failure, because the files in the ci are not accessible to actually check what went wrong. 
if both are not set the it behaves as before

required for pr https://github.com/asyncvlsi/actflow/pull/1