### PR TITLE
fix missing reference for Act object destructor

### DIFF
--- a/act/act.h
+++ b/act/act.h
@@ -432,7 +432,7 @@ class Act {
    * read.
    */
   Act (const char *s = NULL);
-  ~Act ();
+  ~Act () = default;
 
   /** 
    * Merge in ACT file "s" into current ACT database


### PR DESCRIPTION
When using smart pointer objects, the compiler expects a call to the destructor, but there is no destructor implementation in source. This fixes the issue by using the default destructor for the time being.