### PR TITLE
expr_dag bugfix

### DIFF
--- a/act/expr_dag.cc
+++ b/act/expr_dag.cc
@@ -109,7 +109,7 @@ static Expr *_expr_todag (struct cHashtable *H, Expr *e)
   case E_BUILTIN_INT:
     ret->u.e.l = REC_CALL (e->u.e.l);
     // constants, so unique already and hashed
-    ret->u.e.r = expr_dup (e->u.e.r);
+    ret->u.e.r = e->u.e.r;
     break;
     
   case E_BUILTIN_BOOL:

--- a/act/expr_dag.cc
+++ b/act/expr_dag.cc
@@ -109,7 +109,7 @@ static Expr *_expr_todag (struct cHashtable *H, Expr *e)
   case E_BUILTIN_INT:
     ret->u.e.l = REC_CALL (e->u.e.l);
     // constants, so unique already and hashed
-    ret->u.e.r = e->u.e.r;
+    ret->u.e.r = expr_dup (e->u.e.r);
     break;
     
   case E_BUILTIN_BOOL:
@@ -144,6 +144,7 @@ static Expr *_expr_todag (struct cHashtable *H, Expr *e)
 
   case E_CONCAT:
     {
+      Expr *e_save = e;
       Expr *tmp = ret;
       while (e) {
 	tmp->u.e.l = REC_CALL (e->u.e.l);
@@ -156,6 +157,7 @@ static Expr *_expr_todag (struct cHashtable *H, Expr *e)
 	}
 	e = e->u.e.r;
       }
+      e = e_save;
     }
     break;
 


### PR DESCRIPTION
pointer to original input `e` is lost during the E_CONCAT traversal. This causes a bug later in the code section starting line 190 onwards.