### PR TITLE
Add `bool_negate_var` to BDD library

### DIFF
--- a/common/bool.h
+++ b/common/bool.h
@@ -84,12 +84,12 @@ typedef struct bool_t {
 
 enum triple_operations_t {
   BOOL_AND = 0, BOOL_OR = 1, BOOL_XOR = 2, BOOL_IMPLIES = 3, BOOL_NOT = 4,
-  BOOL_MKTRUE = 5, BOOL_MKFALSE = 6
+  BOOL_MKTRUE = 5, BOOL_MKFALSE = 6, BOOL_NEGATE_VAR = 7
   } ;
 
 #endif
 
-#define BOOL_MAXOP 7
+#define BOOL_MAXOP 8
 
 typedef struct {
   unsigned long nelements;	/* number of elements in the hashtable */
@@ -144,6 +144,7 @@ extern bool_t *bool_implies (BOOL_T *, bool_t *, bool_t *);
 extern bool_t *bool_maketrue (BOOL_T *, bool_t *, bool_t *);
 extern bool_t *bool_makefalse (BOOL_T *, bool_t *, bool_t *);
 
+extern bool_t *bool_negate_var (BOOL_T *, bool_t *, bool_t *);
 extern bool_t *bool_substitute (BOOL_T *, bool_list_t *, bool_list_t *, 
 				bool_t *);
 extern bool_t *bool_exists (BOOL_T *, bool_list_t *, bool_t *);


### PR DESCRIPTION
Add `bool_negate_var` to the BDD library.

This function negates all instances of a variable in a BDD. For example, say you have a BDD for `(A & ~B & C) | (~A & ~C)`. Running `bool_negate_var` for the `A` variable will yield `(~A & ~B & C) | (A & ~C)`.

I've found this useful for working with the BDD representation of the state space, and I'm happy to provide an example if it would be helpful.

Also, if there's a better name, I'm definitely open to alternatives.
